### PR TITLE
Release landlock 0.2.0.1

### DIFF
--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Revision history for landlock
 
+## 0.2.0.2 -- YYYY-mm-dd
+
 ## 0.2.0.1 -- 2022-08-24
 
 * Code-wise the same as version 0.2.0.0, but said version was incorrectly

--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision history for landlock
 
-## 0.2.0.1 -- YYYY-mm-dd
+## 0.2.0.1 -- 2022-08-24
+
+* Code-wise the same as version 0.2.0.0, but said version was incorrectly
+  published on Hackage, hence re-releasing.
 
 ## 0.2.0.0 -- 2022-08-24
 

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -2,7 +2,7 @@ Cabal-Version:       2.2
 Build-Type:          Simple
 
 Name:                landlock
-Version:             0.2.0.1
+Version:             0.2.0.2
 Synopsis:            Haskell bindings for the Linux Landlock API
 Description:
   This library exposes Haskell bindings for the Linux kernel Landlock API.


### PR DESCRIPTION
Sadly enough, I managed to upload an incorrect tarball to Hackage for landlock 0.2.0.0 :disappointed: Hence, need a new release, which is code-wise the same.