### PR TITLE
ci: run all tests

### DIFF
--- a/.github/workflows/haskell-ci.patch
+++ b/.github/workflows/haskell-ci.patch
@@ -1,13 +1,19 @@
 diff --git a/.github/workflows/haskell-ci.yml b/.github/workflows/haskell-ci.yml
-index 3e30b63..57c4a1e 100644
+index 5147875..614cc9c 100644
 --- a/.github/workflows/haskell-ci.yml
 +++ b/.github/workflows/haskell-ci.yml
-@@ -23,7 +23,7 @@ jobs:
+@@ -19,11 +19,12 @@ on:
+ jobs:
+   linux:
+     name: Haskell-CI - Linux - ${{ matrix.compiler }}
+-    runs-on: ubuntu-18.04
++    runs-on: ubuntu-22.04
      timeout-minutes:
        60
      container:
 -      image: buildpack-deps:bionic
 +      image: buildpack-deps:jammy
++      options: --security-opt seccomp=unconfined
      continue-on-error: ${{ matrix.allow-failure }}
      strategy:
        matrix:

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -19,11 +19,12 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:
       image: buildpack-deps:jammy
+      options: --security-opt seccomp=unconfined
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,1 @@
-github-patches: .github/workflows/ubuntu-jammy.patch
+github-patches: .github/workflows/haskell-ci.patch

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -96,7 +96,6 @@ Test-Suite landlock-test
                      , process ^>=1.6.9.0
                      , QuickCheck ^>=2.14.2
                      , tasty ^>=1.4.1
-                     , tasty-expected-failure ^>=0.12.3
                      , tasty-hunit ^>=0.10.0.3
                      , tasty-quickcheck ^>=0.10.1.2
   Default-Language:    Haskell2010
@@ -116,7 +115,6 @@ Test-Suite landlock-test-threaded
                      , base
                      , async ^>=2.2.3
                      , tasty ^>=1.4.1
-                     , tasty-expected-failure ^>=0.12.3
                      , tasty-hunit ^>=0.10.0.3
   Default-Language:    Haskell2010
   Ghc-Options:         -Wall -threaded -with-rtsopts -N2

--- a/landlock/test/landlock-test-threaded.hs
+++ b/landlock/test/landlock-test-threaded.hs
@@ -3,18 +3,11 @@ module Main (main) where
 import Control.Concurrent.Async (withAsyncBound)
 
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.ExpectedFailure (expectFailBecause)
-
-import System.Landlock (isSupported)
 
 import ThreadedScenario (scenario)
 
 main :: IO ()
 main = do
-    supported <- isSupported
-    let scenario' = scenario withAsyncBound
     defaultMain $ testGroup "Threaded" [
-          if supported
-            then scenario'
-            else expectFailBecause "Landlock not supported" scenario'
+          scenario withAsyncBound
         ]


### PR DESCRIPTION
Previously, tests actually using the Landlock kernel API were allowed to
fail if Landlock was not supported in the test environment. This was the
case on Ubuntu 18.04 runners in the GitHub Actions environment, because
of the old Linux kernel version used.

Hence, actual Landlock functionality was not tested (in CI, at least).

The Ubuntu 22.04 runners, which come with a new kernel version which
does have support for Landlock, also failed to execute the tests (or
rather, executed them with expected failures). It turns out the version
of Moby/Docker used in this environment comes with a `seccomp` profile
which doesn't allow the Landlock syscalls to be performed (this was
added in Moby version 22.06-beta.0).

However, on GitHub Actions, we can configure how `docker build` is
invoked. This allows the `seccomp` profile to be configured as
`unconfined`, effectively allowing the use of Landlock APIs (and more,
of course).

This patch

- Configures the `Haskell-CI` GitHub Actions workflow to run in the
  `ubuntu-22.04` environment
- Configures GitHub Actions to pass the `--security-opt
  seccomp=unconfined` argument to `docker build`
- Removes the "expected failure" wrappers of all tests

See: https://github.com/moby/moby/blob/v20.10.17/profiles/seccomp/default.json
See: https://github.com/moby/moby/commit/af819bf623a8d414289b24f9817c6317cf3f96d5