### PR TITLE
tests: check typeclass laws of instances using `quickcheck-classes`

### DIFF
--- a/landlock/internal/System/Landlock/Flags.hsc
+++ b/landlock/internal/System/Landlock/Flags.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 
 module System.Landlock.Flags (
@@ -7,6 +9,12 @@ module System.Landlock.Flags (
     , accessFsFlagToBit
     , accessFsFlags
     , accessFsFlagIsReadOnly
+    , CreateRulesetFlag(..)
+    , createRulesetFlagToBit
+    , RestrictSelfFlag
+    , restrictSelfFlagToBit
+    , AddRuleFlag
+    , addRuleFlagToBit
     ) where
 
 #include <linux/landlock.h>
@@ -117,3 +125,36 @@ accessFsFlagIsReadOnly = \case
     AccessFsMakeFifo -> False
     AccessFsMakeBlock -> False
     AccessFsMakeSym -> False
+
+
+-- | Flags passed to @landlock_create_ruleset@.
+--
+-- In the current kernel API, only @LANDLOCK_CREATE_RULESET_VERSION@ is
+-- defined, which should not be used when creating an actual Landlock
+-- encironment (cf. 'landlock').
+data CreateRulesetFlag = CreateRulesetVersion
+  deriving (Show, Eq, Enum, Bounded)
+
+createRulesetFlagToBit :: Num a => CreateRulesetFlag -> a
+createRulesetFlagToBit = \case
+    CreateRulesetVersion -> #{const LANDLOCK_CREATE_RULESET_VERSION}
+
+-- | Flags passed to @landlock_restrict_self@.
+--
+-- In the current kernel API, no such flags are defined, hence this is a type
+-- without any constructors.
+data RestrictSelfFlag
+  deriving (Show, Eq)
+
+restrictSelfFlagToBit :: Num a => RestrictSelfFlag -> a
+restrictSelfFlagToBit = \case {}
+
+-- | Flags passed to @landlock_add_rule@.
+--
+-- In the current kernel API, no such flags are defined, hence this is a type
+-- without any constructors.
+data AddRuleFlag
+  deriving (Show, Eq)
+
+addRuleFlagToBit :: Num a => AddRuleFlag -> a
+addRuleFlagToBit = \case {}

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -52,9 +52,7 @@ Library
   Build-Tool-Depends:  hsc2hs:hsc2hs
   Hs-Source-Dirs:      src
   Default-Language:    Haskell2010
-  Other-Extensions:    EmptyCase
-                       EmptyDataDeriving
-                       FlexibleContexts
+  Other-Extensions:    FlexibleContexts
                        LambdaCase
                        RankNTypes
   Ghc-Options:         -Wall
@@ -76,6 +74,8 @@ Library landlock-internal
   Hs-Source-Dirs:      internal
   Default-Language:    Haskell2010
   Other-Extensions:    DataKinds
+                       EmptyCase
+                       EmptyDataDeriving
                        FlexibleInstances
                        GADTs
                        KindSignatures
@@ -94,7 +94,7 @@ Test-Suite landlock-test
                      , async ^>=2.2.3
                      , filepath ^>=1.4.2.1
                      , process ^>=1.6.9.0
-                     , QuickCheck ^>=2.14.2
+                     , quickcheck-classes-base ^>=0.6.2.0
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
                      , tasty-quickcheck ^>=0.10.1.2
@@ -102,7 +102,6 @@ Test-Suite landlock-test
   Other-Extensions:    DataKinds
                        FlexibleInstances
                        LambdaCase
-                       ScopedTypeVariables
                        TypeApplications
   Ghc-Options:         -Wall
 


### PR DESCRIPTION
Instead of having some hand-rolled minimal laws check for `Storable`,
use `quickcheck-classes` to validate a bunch of laws on a bunch of
datatypes.

See: https://hackage.haskell.org/package/quickcheck-classes