### PR TITLE
landlock, psx: support GHC 9.4.2

### DIFF
--- a/.github/workflows/haskell-ci.patch
+++ b/.github/workflows/haskell-ci.patch
@@ -6,7 +6,7 @@ index 5147875..614cc9c 100644
  jobs:
    linux:
      name: Haskell-CI - Linux - ${{ matrix.compiler }}
--    runs-on: ubuntu-18.04
+-    runs-on: ubuntu-20.04
 +    runs-on: ubuntu-22.04
      timeout-minutes:
        60

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20220826
 #
-# REGENDATA ("0.14.3",["github","cabal.project"])
+# REGENDATA ("0.15.20220826",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -29,6 +29,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.2
             compilerKind: ghc
             compilerVersion: 9.2.2
@@ -51,10 +56,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -220,7 +225,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Support Landlock ABI v2 and `LANDLOCK_ACCESS_FS_REFER` as part of it.
 
+* Support GHC 9.4.2 / `base ^>=4.17`.
+
 ## 0.2.0.1 -- 2022-08-24
 
 * Code-wise the same as version 0.2.0.0, but said version was incorrectly

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -39,6 +39,7 @@ Extra-Source-Files:
 Tested-With:         GHC ==8.10.5
                    , GHC ==9.0.2
                    , GHC ==9.2.2
+                   , GHC ==9.4.2
 
 Source-Repository head
   Type:                git
@@ -49,7 +50,7 @@ Source-Repository head
 Library
   Exposed-Modules:     System.Landlock
   Build-Depends:       landlock-internal
-                     , base ^>=4.14.2.0 || ^>=4.15 || ^>=4.16
+                     , base ^>=4.14.2.0 || ^>=4.15 || ^>=4.16 || ^>=4.17
                      , exceptions ^>=0.10.4
                      , unix ^>=2.7.2.2
   Hs-Source-Dirs:      src

--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Revision history for psx
 
-## 0.1.0.1 -- YYYY-mm-dd
+## 0.1.1.0 -- YYYY-mm-dd
 
 * Rely on `_POSIX_C_SOURCE >= 1` instead of `_GNU_SOURCE` as feature test macro
   for `sigset_t` in `hs-psx.c`.
+
+* Support GHC 9.4.2 / `base ^>=4.17`.
 
 ## 0.1.0.0 -- 2022-08-24
 

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -2,7 +2,7 @@ Cabal-Version:       2.2
 Build-Type:          Simple
 
 Name:                psx
-Version:             0.1.0.1
+Version:             0.1.1.0
 Synopsis:            Integrate libpsx with the GHC RTS
 Description:
   This library embeds @libpsx@ in a GHC Haskell-compiled application.
@@ -38,6 +38,7 @@ Extra-Source-Files:
 Tested-With:         GHC ==8.10.5
                    , GHC ==9.0.2
                    , GHC ==9.2.2
+                   , GHC ==9.4.2
 
 Source-Repository head
   Type:                git
@@ -60,7 +61,7 @@ Library
   -- restrict compatibility with said GHC version(s).
   Exposed-Modules:     System.PSX
   Hs-Source-Dirs:      src
-  Build-Depends:       base ^>=4.14.2.0 || ^>=4.15 || ^>=4.16
+  Build-Depends:       base ^>=4.14.2.0 || ^>=4.15 || ^>=4.16 || ^>=4.17
   Include-Dirs:        cbits
   Install-Includes:    hs-psx.h
   C-Sources:           cbits/hs-psx.c


### PR DESCRIPTION
The CI workflow was (re)generated by a snapshot of `haskell-ci`, a5bacf0ee66.