### PR TITLE
psx, landlock: move compiler warnings into package description

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -168,30 +168,10 @@ jobs:
           allow-newer: process-1.6.15.0:unix
 
           package landlock
-            ghc-options:
-              -Werror
-              -Wall
-              -Wincomplete-uni-patterns
-              -Wincomplete-record-updates
-              -Wpartial-fields
-              -Wmissing-home-modules
-              -Widentities
-              -Wredundant-constraints
-              -Wcpp-undef
-              -Wmissing-export-lists
+            ghc-options: -Werror -optc=-Werror
 
           package psx
-            ghc-options:
-              -Werror
-              -Wall
-              -Wincomplete-uni-patterns
-              -Wincomplete-record-updates
-              -Wpartial-fields
-              -Wmissing-home-modules
-              -Widentities
-              -Wredundant-constraints
-              -Wcpp-undef
-              -Wmissing-export-lists
+            ghc-options: -Werror -optc=-Werror
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(landlock|psx)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,5 +1,9 @@
 Github-Patches: .github/workflows/haskell-ci.patch
-Copy-Fields: all
+Copy-Fields: some
+
+Local-Ghc-Options:
+  -Werror
+  -optc=-Werror
 
 Constraint-Set unix-2.7
   Constraints: unix ^>=2.7

--- a/cabal.project
+++ b/cabal.project
@@ -5,26 +5,17 @@ Allow-Newer:
   -- https://github.com/haskell/process/pull/260
   process-1.6.15.0:unix
 
+-- Note: when making changes, they likely need to be applied to the
+-- other local libraries as well (for some reason, unlike as documented,
+-- having them at the top-level doesn't work as expected).
+-- Furthermore, when making changes, the `Local-Ghc-Options` value in
+-- `cabal.haskell-ci` must be updated as well.
 Package landlock
-  Ghc-Options: -Werror
-               -Wall
-               -Wincomplete-uni-patterns
-               -Wincomplete-record-updates
-               -Wpartial-fields
-               -Wmissing-home-modules
-               -Widentities
-               -Wredundant-constraints
-               -Wcpp-undef
-               -Wmissing-export-lists
+  Ghc-Options:
+    -Werror
+    -optc=-Werror
 
 Package psx
-  Ghc-Options: -Werror
-               -Wall
-               -Wincomplete-uni-patterns
-               -Wincomplete-record-updates
-               -Wpartial-fields
-               -Wmissing-home-modules
-               -Widentities
-               -Wredundant-constraints
-               -Wcpp-undef
-               -Wmissing-export-lists
+  Ghc-Options:
+    -Werror
+    -optc=-Werror

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -47,18 +47,36 @@ Source-Repository head
   Subdir:              landlock
   Branch:              main
 
+Common common-settings
+  Default-Language:    Haskell2010
+  Ghc-Options:
+    -Wall
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Wmissing-home-modules
+    -Widentities
+    -Wredundant-constraints
+    -Wcpp-undef
+    -Wmissing-export-lists
+  Cc-Options:
+    -Wall
+    -Wextra
+    -pedantic
+
 Library
+  Import:              common-settings
   Exposed-Modules:     System.Landlock
   Build-Depends:       landlock-internal
                      , base ^>=4.14.2.0 || ^>=4.15 || ^>=4.16 || ^>=4.17
                      , exceptions ^>=0.10.4
                      , unix ^>=2.7.2.2 || ^>=2.8
   Hs-Source-Dirs:      src
-  Default-Language:    Haskell2010
   Other-Extensions:    FlexibleContexts
                        RankNTypes
 
 Library landlock-internal
+  Import:              common-settings
   Exposed-Modules:     System.Landlock.Flags
                      , System.Landlock.OpenPath
                      , System.Landlock.Rules
@@ -66,14 +84,12 @@ Library landlock-internal
                      , System.Landlock.Version
   Include-Dirs:        cbits
   C-Sources:           cbits/hs-landlock.c
-  Cc-Options:          -Wall
   Build-Depends:       psx ^>=0.1
                      , base
                      , exceptions
                      , unix
   Build-Tool-Depends:  hsc2hs:hsc2hs
   Hs-Source-Dirs:      internal
-  Default-Language:    Haskell2010
   Other-Extensions:    DataKinds
                        EmptyCase
                        EmptyDataDeriving
@@ -84,6 +100,7 @@ Library landlock-internal
                        StandaloneDeriving
 
 Executable landlocked
+  Import:              common-settings
   Main-Is:             landlocked.hs
   Other-Modules:       Paths_landlock
   Autogen-Modules:     Paths_landlock
@@ -93,9 +110,9 @@ Executable landlocked
                      , exceptions ^>=0.10.4
                      , optparse-applicative ^>=0.16.1.0
                      , unix ^>=2.7.2.2 || ^>=2.8
-  Default-Language:    Haskell2010
 
 Test-Suite landlock-test
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             landlock-test.hs
@@ -110,13 +127,13 @@ Test-Suite landlock-test
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
                      , tasty-quickcheck ^>=0.10.1.2
-  Default-Language:    Haskell2010
   Other-Extensions:    DataKinds
                        FlexibleInstances
                        LambdaCase
                        TypeApplications
 
 Test-Suite landlock-test-threaded
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             landlock-test-threaded.hs
@@ -126,10 +143,10 @@ Test-Suite landlock-test-threaded
                      , async ^>=2.2.3
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
-  Default-Language:    Haskell2010
   Ghc-Options:         -threaded -with-rtsopts -N2
 
 Test-Suite landlock-readme
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Main-Is:             README.lhs
   Other-Modules:       ReadmeUtils
@@ -142,10 +159,10 @@ Test-Suite landlock-readme
                      , process ^>=1.6.9.0
                      , temporary ^>=1.3
   Build-Tool-Depends:  markdown-unlit:markdown-unlit
-  Default-Language:    Haskell2010
   Ghc-Options:         -pgmL markdown-unlit
 
 Test-Suite landlocked-test
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             landlocked-test.hs
@@ -156,4 +173,3 @@ Test-Suite landlocked-test
                      , tasty-hunit ^>=0.10.0.3
                      , temporary ^>=1.3
   Build-Tool-Depends:  landlock:landlocked
-  Default-Language:    Haskell2010

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -51,7 +51,25 @@ Flag bundled-libpsx
   Default:             True
   Manual:              True
 
+Common common-settings
+  Default-Language:    Haskell2010
+  Ghc-Options:
+    -Wall
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Wmissing-home-modules
+    -Widentities
+    -Wredundant-constraints
+    -Wcpp-undef
+    -Wmissing-export-lists
+  Cc-Options:
+    -Wall
+    -Wextra
+    -pedantic
+
 Library
+  Import: common-settings
   -- Despite this library not containing any Haskell code, and
   -- hence not really having any dependency on `base`, it is
   -- only *tested* on particular GHC versions (which we can tie
@@ -65,9 +83,7 @@ Library
   Include-Dirs:        cbits
   Install-Includes:    hs-psx.h
   C-Sources:           cbits/hs-psx.c
-  Cc-Options:          -Wall
   Ld-Options:          -Wl,-wrap,sigfillset -Wl,-undefined,__wrap_sigfillset
-  Default-Language:    Haskell2010
   if flag(bundled-libpsx)
     C-Sources:         cbits/psx/psx.c
     Cc-Options:        -DBUNDLED_LIBPSX
@@ -76,6 +92,7 @@ Library
     Pkgconfig-Depends: libpsx
 
 Test-Suite psx-test-threaded
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             psx-test-threaded.hs
@@ -87,10 +104,10 @@ Test-Suite psx-test-threaded
                      , async ^>=2.2.3
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
-  Default-Language:    Haskell2010
   Ghc-Options:         -threaded -with-rtsopts -N2
 
 Test-Suite psx-test
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             psx-test.hs
@@ -102,9 +119,9 @@ Test-Suite psx-test
                      , async ^>=2.2.3
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
-  Default-Language:    Haskell2010
 
 Test-Suite psx-test-no-psx
+  Import:              common-settings
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             psx-test-no-psx.hs
@@ -114,4 +131,3 @@ Test-Suite psx-test-no-psx
   Build-Depends:       base
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
-  Default-Language:    Haskell2010


### PR DESCRIPTION
These were moved into `cabal.project` before, but after inquiry on `haskell-cafe`, they should be in the Cabal package description instead.

Using common stanzas, this isn't all too painful.

`-Werror` and friends are still enabled in `cabal.project` for local development, as well as in CI.

See: https://mail.haskell.org/pipermail/haskell-cafe/2022-August/135476.html