### PR TITLE
landlock, psx: use `capi` foreign imports

### DIFF
--- a/landlock/internal/System/Landlock/OpenPath.hsc
+++ b/landlock/internal/System/Landlock/OpenPath.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module System.Landlock.OpenPath (
       withOpenPath
     , withOpenPathAt
@@ -18,7 +20,7 @@ import System.Posix.Error (throwErrnoPathIfMinus1Retry)
 import System.Posix.IO (closeFd)
 import System.Posix.Types (Fd)
 
-foreign import ccall unsafe "fcntl.h openat"
+foreign import capi unsafe "fcntl.h openat"
   _openat :: #{type int}
          -> CString
          -> #{type int}

--- a/landlock/internal/System/Landlock/Syscalls.hsc
+++ b/landlock/internal/System/Landlock/Syscalls.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module System.Landlock.Syscalls (
       LandlockRulesetAttr(..)
     , landlock_create_ruleset
@@ -33,7 +35,7 @@ instance Storable LandlockRulesetAttr where
   poke ptr attr = do
       #{poke struct landlock_ruleset_attr, handled_access_fs} ptr (landlockRulesetAttrHandledAccessFs attr)
 
-foreign import ccall unsafe "hs-landlock.h landlock_create_ruleset"
+foreign import capi unsafe "hs-landlock.h landlock_create_ruleset"
   _landlock_create_ruleset :: Ptr LandlockRulesetAttr
                            -> #{type size_t}
                            -> #{type __u32}
@@ -46,7 +48,7 @@ landlock_create_ruleset :: Ptr LandlockRulesetAttr
 landlock_create_ruleset attr size flags =
     throwErrnoIfMinus1 "landlock_create_ruleset" $ _landlock_create_ruleset attr size flags
 
-foreign import ccall unsafe "hs-landlock.h landlock_add_rule"
+foreign import capi unsafe "hs-landlock.h landlock_add_rule"
   _landlock_add_rule :: #{type int}
                      -> #{type enum landlock_rule_type}
                      -> Ptr a
@@ -63,7 +65,7 @@ landlock_add_rule ruleset_fd rule_type rule_attr flags =
         throwErrnoIfMinus1 "landlock_add_rule" $
             _landlock_add_rule ruleset_fd rule_type rule_attr flags
 
-foreign import ccall unsafe "hs-landlock.h landlock_restrict_self"
+foreign import capi unsafe "hs-landlock.h landlock_restrict_self"
   _landlock_restrict_self :: #{type int}
                           -> #{type __u32}
                           -> IO #{type long}
@@ -76,7 +78,7 @@ landlock_restrict_self ruleset_fd flags =
         throwErrnoIfMinus1 "landlock_restrict_self" $
             _landlock_restrict_self ruleset_fd flags
 
-foreign import ccall unsafe "hs-landlock.h hs_landlock_prctl"
+foreign import capi unsafe "hs-landlock.h hs_landlock_prctl"
   _prctl :: #{type int}
         -> #{type unsigned long}
         -> #{type unsigned long}

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -90,7 +90,8 @@ Library landlock-internal
                      , unix
   Build-Tool-Depends:  hsc2hs:hsc2hs
   Hs-Source-Dirs:      internal
-  Other-Extensions:    DataKinds
+  Other-Extensions:    CApiFFI
+                       DataKinds
                        EmptyCase
                        EmptyDataDeriving
                        FlexibleInstances
@@ -127,7 +128,8 @@ Test-Suite landlock-test
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
                      , tasty-quickcheck ^>=0.10.1.2
-  Other-Extensions:    DataKinds
+  Other-Extensions:    CApiFFI
+                       DataKinds
                        FlexibleInstances
                        LambdaCase
                        TypeApplications
@@ -144,6 +146,7 @@ Test-Suite landlock-test-threaded
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
   Ghc-Options:         -threaded -with-rtsopts -N2
+  Other-Extensions:    CApiFFI
 
 Test-Suite landlock-readme
   Import:              common-settings

--- a/landlock/test/ThreadedScenario.hs
+++ b/landlock/test/ThreadedScenario.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module ThreadedScenario (scenario) where
 
 import Control.Concurrent.Async (Async, wait)
@@ -12,7 +14,7 @@ import Test.Tasty.HUnit (assertFailure, testCaseSteps)
 
 import System.Landlock (AccessFsFlag(..), RulesetAttr(..), landlock)
 
-foreign import ccall unsafe "unistd.h gettid"
+foreign import capi unsafe "unistd.h gettid"
     gettid :: IO CPid
 
 scenario :: (IO () -> (Async () -> IO ()) -> IO ()) -> TestTree

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -105,6 +105,7 @@ Test-Suite psx-test-threaded
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
   Ghc-Options:         -threaded -with-rtsopts -N2
+  Other-Extensions:    CApiFFI
 
 Test-Suite psx-test
   Import:              common-settings
@@ -119,6 +120,7 @@ Test-Suite psx-test
                      , async ^>=2.2.3
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
+  Other-Extensions:    CApiFFI
 
 Test-Suite psx-test-no-psx
   Import:              common-settings
@@ -131,3 +133,4 @@ Test-Suite psx-test-no-psx
   Build-Depends:       base
                      , tasty ^>=1.4.1
                      , tasty-hunit ^>=0.10.0.3
+  Other-Extensions:    CApiFFI

--- a/psx/test/TestCases.hsc
+++ b/psx/test/TestCases.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module TestCases (
       psxSyscall3Works
     , psxSyscall6Works
@@ -25,14 +27,14 @@ import Foreign.Storable (Storable(..))
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit ((@?=), assertBool, testCase, testCaseSteps)
 
-foreign import ccall unsafe "hs-psx.h hs_psx_syscall3"
+foreign import capi unsafe "hs-psx.h hs_psx_syscall3"
     psxSyscall3 :: #{type long}
                 -> #{type long}
                 -> #{type long}
                 -> #{type long}
                 -> IO #{type long}
 
-foreign import ccall unsafe "hs-psx.h hs_psx_syscall6"
+foreign import capi unsafe "hs-psx.h hs_psx_syscall6"
     psxSyscall6 :: #{type long}
                 -> #{type long}
                 -> #{type long}
@@ -42,13 +44,13 @@ foreign import ccall unsafe "hs-psx.h hs_psx_syscall6"
                 -> #{type long}
                 -> IO #{type long}
 
-foreign import ccall unsafe "unistd.h getpid"
+foreign import capi unsafe "unistd.h getpid"
     c_getpid :: IO #{type pid_t}
 
 getpid :: IO #{type pid_t}
 getpid = throwErrnoIfMinus1 "getpid" c_getpid
 
-foreign import ccall unsafe "unistd.h gettid"
+foreign import capi unsafe "unistd.h gettid"
     c_gettid :: IO #{type pid_t}
 
 gettid :: IO #{type pid_t}
@@ -66,7 +68,7 @@ psxSyscall6Works = testCase "hs_psx_syscall6 works" $ do
     void $ throwErrnoIfMinus1 "prctl" $ psxSyscall6 #{const __NR_prctl} #{const PR_GET_NO_NEW_PRIVS} 0 0 0 0 0
 
 
-foreign import ccall unsafe "sys/prctl.h prctl"
+foreign import capi unsafe "sys/prctl.h prctl"
     _prctl :: #{type int}
            -> #{type unsigned long}
            -> #{type unsigned long}
@@ -147,10 +149,10 @@ instance Storable SigsetT where
     peek _ = error "peek not implemented"
     poke _ _ = error "poke not implemented"
 
-foreign import ccall unsafe "signal.h sigfillset"
+foreign import capi unsafe "signal.h sigfillset"
     sigfillset :: Ptr SigsetT -> IO #{type int}
 
-foreign import ccall unsafe "signal.h sigismember"
+foreign import capi unsafe "signal.h sigismember"
     sigismember :: Ptr SigsetT -> #{type int} -> IO #{type int}
 
 sigfillsetWrapped :: TestTree
@@ -160,7 +162,7 @@ sigfillsetWrapped = testCase "sigfillset is wrapped" $ alloca $ \set -> do
     isMember @?= 0
 
 
-foreign import ccall unsafe "detect-psx.h detect_psx"
+foreign import capi unsafe "detect-psx.h detect_psx"
     detectPsx :: IO #{type int}
 
 psxDetected :: TestTree

--- a/psx/test/psx-test-no-psx.hsc
+++ b/psx/test/psx-test-no-psx.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module Main (main) where
 
 #include "hs-psx.h"
@@ -25,10 +27,10 @@ instance Storable SigsetT where
     peek _ = error "peek not implemented"
     poke _ _ = error "poke not implemented"
 
-foreign import ccall unsafe "signal.h sigfillset"
+foreign import capi unsafe "signal.h sigfillset"
     sigfillset :: Ptr SigsetT -> IO #{type int}
 
-foreign import ccall unsafe "signal.h sigismember"
+foreign import capi unsafe "signal.h sigismember"
     sigismember :: Ptr SigsetT -> #{type int} -> IO #{type int}
 
 sigfillsetNotWrapped :: IO ()
@@ -38,7 +40,7 @@ sigfillsetNotWrapped = alloca $ \set -> do
     isMember @?= 1
 
 
-foreign import ccall unsafe "detect-psx.h detect_psx"
+foreign import capi unsafe "detect-psx.h detect_psx"
     detectPsx :: IO #{type int}
 
 psxNotDetected :: IO ()


### PR DESCRIPTION
Instead of using `foreign import ccall`, use `foreign import capi` through the `CApiFFI` extension, to ensure we call C functions correctly (the call signature is now being checked by the C compiler).

This causes, in theory, a slight performance impact, but given the Landlock calls aren't performance-sensitive, this shouldn't be an issue.

See: https://www.haskell.org/ghc/blog/20210709-capi-usage.html
See: https://well-typed.com/blog/2021/08/capi-usage/
See: https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/exts/ffi.html?highlight=capiffi#extension-CApiFFI