### PR TITLE
landlock: add `landlocked` flag

### DIFF
--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Add a new executable,`landlocked`, which permits to run a command in
   a sandboxed environment.
 
+* Add a flag, `landlocked`, which allows to not build the `landlocked`
+  executable.
+
 ## 0.2.0.1 -- 2022-08-24
 
 * Code-wise the same as version 0.2.0.0, but said version was incorrectly

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -47,6 +47,11 @@ Source-Repository head
   Subdir:              landlock
   Branch:              main
 
+Flag landlocked
+  Description:         Build the landlocked utility.
+  Default:             True
+  Manual:              False
+
 Common common-settings
   Default-Language:    Haskell2010
   Ghc-Options:
@@ -102,6 +107,8 @@ Library landlock-internal
 
 Executable landlocked
   Import:              common-settings
+  if !flag(landlocked)
+    Buildable:         False
   Main-Is:             landlocked.hs
   Other-Modules:       Paths_landlock
   Autogen-Modules:     Paths_landlock
@@ -166,6 +173,8 @@ Test-Suite landlock-readme
 
 Test-Suite landlocked-test
   Import:              common-settings
+  if !flag(landlocked)
+    Buildable:         False
   Type:                exitcode-stdio-1.0
   Hs-Source-Dirs:      test
   Main-Is:             landlocked-test.hs


### PR DESCRIPTION
Setting the flag to `False` will result in the `landlocked` utility not to be built.

This could be useful if at some point one wants to build the library in an environment where the `landlocked` `Build-Depends` would conflict with other dependencies. Or if one simply doesn't want the utility to be installed.