### PR TITLE
landlock: set the `landlocked` flag to `Manual`

### DIFF
--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -50,7 +50,7 @@ Source-Repository head
 Flag landlocked
   Description:         Build the landlocked utility.
   Default:             True
-  Manual:              False
+  Manual:              True
 
 Common common-settings
   Default-Language:    Haskell2010


### PR DESCRIPTION
Without this setting, the utility isn't built when Cabal selects some dependency versions it's not compatible with.

Instead, require the flag to be (un)set explicitly by the user.