### PR TITLE
landlock: rework `accessFsFlags` implementation

### DIFF
--- a/landlock/internal/System/Landlock/Flags.hsc
+++ b/landlock/internal/System/Landlock/Flags.hsc
@@ -123,10 +123,27 @@ accessFsFlagToBit = \case
 
 -- | All 'AccessFsFlag' flags keyed by a Landlock ABI 'Version'.
 accessFsFlags :: [(Version, [AccessFsFlag])]
-accessFsFlags = [
-      (version1, [AccessFsExecute .. AccessFsMakeSym])
-    , (version2, [AccessFsExecute .. AccessFsRefer])
+accessFsFlags = [(v, [f | f <- [minBound..], version f <= v]) | v <- [
+      version1
+    , version2
     ]
+  ]
+  where
+    version = \case
+      AccessFsExecute -> version1
+      AccessFsWriteFile -> version1
+      AccessFsReadFile -> version1
+      AccessFsReadDir -> version1
+      AccessFsRemoveDir -> version1
+      AccessFsRemoveFile -> version1
+      AccessFsMakeChar -> version1
+      AccessFsMakeDir -> version1
+      AccessFsMakeReg -> version1
+      AccessFsMakeSock -> version1
+      AccessFsMakeFifo -> version1
+      AccessFsMakeBlock -> version1
+      AccessFsMakeSym -> version1
+      AccessFsRefer -> version2
 
 -- | Predicate for read-only 'AccessFsFlag' flags.
 accessFsFlagIsReadOnly :: AccessFsFlag -> Bool
@@ -145,7 +162,6 @@ accessFsFlagIsReadOnly = \case
     AccessFsMakeBlock -> False
     AccessFsMakeSym -> False
     AccessFsRefer -> False
-
 
 -- | Flags passed to @landlock_create_ruleset@.
 --


### PR DESCRIPTION
Instead of relying on the ordering of constructors in the datatype, maintain a mapping of flag to ABI version in the code, and construct the mappings from ABI version to flags set accordingly.

Also, add some unit-tests to check this is done correctly. Right now soem of these rely on the datatype constructors ordering, hence work like the original implementation, but that's fine.

(cherry picked from commit 2f09423f00955d8f63cf420ed381a970ab496390)