### PR TITLE
chore: rework `-Werror` handling

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,2 @@
+-- Disable (default) `-Werror` in the REPL
+:set -Wwarn

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -179,10 +179,10 @@ jobs:
           allow-newer: process-1.6.15.0:unix
 
           package landlock
-            ghc-options: -Werror -optc=-Werror
+            flags: +werror
 
           package psx
-            ghc-options: -Werror -optc=-Werror
+            flags: +werror
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(landlock|psx)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,13 +1,15 @@
 Github-Patches: .github/workflows/haskell-ci.patch
-Copy-Fields: some
 
 Distribution: jammy
 
 Hlint: True
 
-Local-Ghc-Options:
-  -Werror
-  -optc=-Werror
+Raw-Project
+  Package landlock
+    Flags: +werror
+
+  Package psx
+    Flags: +werror
 
 Constraint-Set unix-2.7
   Constraints: unix ^>=2.7

--- a/cabal.project
+++ b/cabal.project
@@ -5,17 +5,9 @@ Allow-Newer:
   -- https://github.com/haskell/process/pull/260
   process-1.6.15.0:unix
 
--- Note: when making changes, they likely need to be applied to the
--- other local libraries as well (for some reason, unlike as documented,
--- having them at the top-level doesn't work as expected).
--- Furthermore, when making changes, the `Local-Ghc-Options` value in
--- `cabal.haskell-ci` must be updated as well.
+-- For non-Hackage builds, enable `-Werror` and friends
 Package landlock
-  Ghc-Options:
-    -Werror
-    -optc=-Werror
+  Flags: +werror
 
 Package psx
-  Ghc-Options:
-    -Werror
-    -optc=-Werror
+  Flags: +werror

--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Use `capi` foreign imports instead of `ccall` using the `CApiFFI` language
   extension.
 
+* Add a Cabal flag, `werror`, to enable compiler `-Werror` and friends.
+
 ## 0.2.0.1 -- 2022-08-24
 
 * Code-wise the same as version 0.2.0.0, but said version was incorrectly

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -52,6 +52,11 @@ Flag landlocked
   Default:             True
   Manual:              True
 
+Flag werror
+  Description:         Turn compiler warnings into errors.
+  Default:             False
+  Manual:              True
+
 Common common-settings
   Default-Language:    Haskell2010
   Ghc-Options:
@@ -68,6 +73,17 @@ Common common-settings
     -Wall
     -Wextra
     -pedantic
+
+  if flag(werror)
+    Ghc-Options:
+      -Werror
+      -optc=-Werror
+    Cc-Options:
+      -Werror
+      -- hsc2hs triggers the following warnings
+      -Wno-error=overlength-strings
+      -Wno-error=type-limits
+      -Wno-error=variadic-macros
 
 Library
   Import:              common-settings

--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * Minor stylistic changes to Cabal package description file.
 
+* Add a Cabal flag, `werror`, to enable compiler `-Werror` and friends.
+
 ## 0.1.0.0 -- 2022-08-24
 
 * First version. Released on an unsuspecting world.

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -51,6 +51,11 @@ Flag bundled-libpsx
   Default:             True
   Manual:              True
 
+Flag werror
+  Description:         Turn compiler warnings into errors.
+  Default:             False
+  Manual:              True
+
 Common common-settings
   Default-Language:    Haskell2010
   Ghc-Options:
@@ -67,6 +72,17 @@ Common common-settings
     -Wall
     -Wextra
     -pedantic
+
+  if flag(werror)
+    Ghc-Options:
+      -Werror
+      -optc=-Werror
+    Cc-Options:
+      -Werror
+      -- hsc2hs triggers the following warnings
+      -Wno-error=overlength-strings
+      -Wno-error=type-limits
+      -Wno-error=variadic-macros
 
 Library
   Import: common-settings


### PR DESCRIPTION
Instead of setting this in `cabal.project`, add a Cabal flag (`werror`) which enables warnings-as-errors in `Ghc-Options` (and related) settings. Then, enable this flag during local builds and in CI (it's disabled by default, however, for Hackage builds).