### PR TITLE
chore: remove `allow-newer` for `process`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -176,8 +176,6 @@ jobs:
           echo "package psx" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
-          allow-newer: process-1.6.15.0:unix
-
           package landlock
             flags: +werror
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,6 @@
 Packages: landlock
           psx
 
-Allow-Newer:
-  -- https://github.com/haskell/process/pull/260
-  process-1.6.15.0:unix
-
 -- For non-Hackage builds, enable `-Werror` and friends
 Package landlock
   Flags: +werror


### PR DESCRIPTION
This is no longer needed since `unix-2.7.3`.