### PR TITLE
chore: split `extra-doc-files` from `extra-source-files`

### DIFF
--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -27,13 +27,15 @@ maintainer:         ikke@nicolast.be
 copyright:          (c) 2022 Nicolas Trangez
 category:           System
 stability:          alpha
-extra-source-files:
-  cbits/hs-landlock.h
+extra-doc-files:
   cbits/linux/GPL-2.0
-  cbits/linux/landlock.h
   cbits/linux/Linux-syscall-note
   CHANGELOG.md
   README.md
+
+extra-source-files:
+  cbits/hs-landlock.h
+  cbits/linux/landlock.h
 
 tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
 

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -26,12 +26,14 @@ maintainer:         ikke@nicolast.be
 copyright:          (c) 2022 Nicolas Trangez
 category:           System
 stability:          alpha
-extra-source-files:
-  cbits/hs-psx.h
+extra-doc-files:
   cbits/psx/License
-  cbits/psx/psx_syscall.h
   CHANGELOG.md
   README.md
+
+extra-source-files:
+  cbits/hs-psx.h
+  cbits/psx/psx_syscall.h
   test/detect-psx.h
 
 tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2


### PR DESCRIPTION
See: https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-extra-doc-files
See: https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-extra-source-files