### PR TITLE
landlock: prefix syscall bindings

### DIFF
--- a/landlock/cbits/hs-landlock.c
+++ b/landlock/cbits/hs-landlock.c
@@ -8,29 +8,31 @@
 #include "hs-landlock.h"
 #include "linux/landlock.h"
 
-#ifndef landlock_create_ruleset
-long landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
-                             const size_t size,
-                             const __u32 flags) {
+long hs_landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
+                                const size_t size,
+                                const __u32 flags) {
+#ifdef landlock_create_ruleset
+        return landlock_create_ruleset(attr, size, flags)
+#else
         return syscall(__NR_landlock_create_ruleset, attr, size, flags);
-}
 #endif
+}
 
-#ifndef landlock_add_rule
-long landlock_add_rule(const int ruleset_fd,
-                       const enum landlock_rule_type rule_type,
-                       const void *const rule_attr,
-                       const __u32 flags) {
+long hs_landlock_add_rule(const int ruleset_fd,
+                          const enum landlock_rule_type rule_type,
+                          const void *const rule_attr,
+                          const __u32 flags) {
+#ifdef landlock_add_rule
+        return landlock_add_rule(ruleset_fd, rule_type, rule_attr, flags)
+#else
         return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type, rule_attr, flags);
-}
 #endif
+}
 
-#ifndef landlock_restrict_self
-long landlock_restrict_self(const int ruleset_fd,
-                            const __u32 flags) {
+long hs_landlock_restrict_self(const int ruleset_fd,
+                               const __u32 flags) {
         return hs_psx_syscall3(__NR_landlock_restrict_self, ruleset_fd, flags, 0);
 }
-#endif
 
 int hs_landlock_prctl(int option,
                       unsigned long arg2,

--- a/landlock/cbits/hs-landlock.h
+++ b/landlock/cbits/hs-landlock.h
@@ -10,15 +10,15 @@
 extern "C" {
 #endif
 
-long landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
-                             const size_t size,
-                             const __u32 flags);
-long landlock_add_rule(const int ruleset_fd,
-                       const enum landlock_rule_type rule_type,
-                       const void *const rule_attr,
-                       const __u32 flags);
-long landlock_restrict_self(const int ruleset_fd,
-                            const __u32 flags);
+long hs_landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
+                                const size_t size,
+                                const __u32 flags);
+long hs_landlock_add_rule(const int ruleset_fd,
+                          const enum landlock_rule_type rule_type,
+                          const void *const rule_attr,
+                          const __u32 flags);
+long hs_landlock_restrict_self(const int ruleset_fd,
+                               const __u32 flags);
 
 int hs_landlock_prctl(int option,
                       unsigned long arg2,

--- a/landlock/internal/System/Landlock/Syscalls.hsc
+++ b/landlock/internal/System/Landlock/Syscalls.hsc
@@ -35,7 +35,7 @@ instance Storable LandlockRulesetAttr where
   poke ptr attr = do
       #{poke struct landlock_ruleset_attr, handled_access_fs} ptr (landlockRulesetAttrHandledAccessFs attr)
 
-foreign import capi unsafe "hs-landlock.h landlock_create_ruleset"
+foreign import capi unsafe "hs-landlock.h hs_landlock_create_ruleset"
   _landlock_create_ruleset :: Ptr LandlockRulesetAttr
                            -> #{type size_t}
                            -> #{type __u32}
@@ -48,7 +48,7 @@ landlock_create_ruleset :: Ptr LandlockRulesetAttr
 landlock_create_ruleset attr size flags =
     throwErrnoIfMinus1 "landlock_create_ruleset" $ _landlock_create_ruleset attr size flags
 
-foreign import capi unsafe "hs-landlock.h landlock_add_rule"
+foreign import capi unsafe "hs-landlock.h hs_landlock_add_rule"
   _landlock_add_rule :: #{type int}
                      -> #{type enum landlock_rule_type}
                      -> Ptr a
@@ -65,7 +65,7 @@ landlock_add_rule ruleset_fd rule_type rule_attr flags =
         throwErrnoIfMinus1 "landlock_add_rule" $
             _landlock_add_rule ruleset_fd rule_type rule_attr flags
 
-foreign import capi unsafe "hs-landlock.h landlock_restrict_self"
+foreign import capi unsafe "hs-landlock.h hs_landlock_restrict_self"
   _landlock_restrict_self :: #{type int}
                           -> #{type __u32}
                           -> IO #{type long}


### PR DESCRIPTION
The syscall bindings in `landlock/cbits/hs-landlock.c` were using the syscall names as-is, which could conflict with implementations in, e.g., `libc`.

Furthermore, the binding to `landlock_restrict_self` is using `libpsx`' interface, hence it's not even a plain binding to the `landlock_restrict_self` syscall.

So, this patch changes all bindings to use the `hs_` prefix (as was already the case for `hs_landlock_prctl`). Internally, they'll use an existing binding (if defined), otherwise use `syscall(2)` as was the original code.