### PR TITLE
chore, ci: use `Constraints` to enable `werror`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -176,11 +176,8 @@ jobs:
           echo "package psx" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
-          package landlock
-            flags: +werror
-
-          package psx
-            flags: +werror
+          constraints: landlock +werror
+          constraints: psx +werror
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(landlock|psx)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -4,13 +4,6 @@ Distribution: jammy
 
 Hlint: True
 
-Raw-Project
-  Package landlock
-    Flags: +werror
-
-  Package psx
-    Flags: +werror
-
 Constraint-Set unix-2.7
   Constraints: unix ^>=2.7
   Tests:       True

--- a/cabal.project
+++ b/cabal.project
@@ -2,8 +2,6 @@ Packages: landlock
           psx
 
 -- For non-Hackage builds, enable `-Werror` and friends
-Package landlock
-  Flags: +werror
-
-Package psx
-  Flags: +werror
+Constraints:
+    landlock +werror
+  , psx +werror


### PR DESCRIPTION
Instead of setting the `werror` flag in entries in `Package` sections in `cabal.project`, which aren't transferred to `haskell-ci.yml` by `haskell-ci`, and hence requires duplication in `cabal.haskell-ci`, enable the flag in a `constraint` definition.