### PR TITLE
psx: don't use `-Wl,-undefined,__wrap_sigfillset` when linking

### DIFF
--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for psx
 
+## 0.1.1.1 -- YYYY-mm-dd
+
+* Remove `-Wl,-undefined,__wrap_sigfillset` from link options.
+
 ## 0.1.1.0 -- 2023-02-22
 
 * Support GHC 9.4.2 / `base ^>=4.17`.

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 build-type:         Simple
 name:               psx
-version:            0.1.1.0
+version:            0.1.1.1
 synopsis:           Integrate libpsx with the GHC RTS
 description:
   This library embeds @libpsx@ in a GHC Haskell-compiled application.
@@ -89,8 +89,7 @@ library
   include-dirs:     cbits
   install-includes: hs-psx.h
   c-sources:        cbits/hs-psx.c
-  ld-options:
-    "-Wl,-wrap,sigfillset" "-Wl,-undefined,__wrap_sigfillset"
+  ld-options:       "-Wl,-wrap,sigfillset"
 
   if flag(bundled-libpsx)
     c-sources:  cbits/psx/psx.c


### PR DESCRIPTION
I'm not sure why this was added in the first place, and it seems not needed at all. Furthermore, this may explain why building on Hackage fails.

See: https://discourse.haskell.org/t/troubleshooting-hackage-doc-build-failures/5888/2