### PR TITLE
psx: update vendored sources

### DIFF
--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 0.1.2.0 -- YYYY-MM-DD
 
-* Update Cabal file formatting
-* Support GHC 9.6.4 / `base ^>=4.18`
-* Support GHC 9.8.2 / `base ^>=4.19`
+* Update Cabal file formatting.
+
+* Support GHC 9.6.4 / `base ^>=4.18`.
+
+* Support GHC 9.8.2 / `base ^>=4.19`.
+
+* Update vendored sources.
 
 ## 0.1.1.1 -- 2023-02-28
 

--- a/psx/cbits/psx/License
+++ b/psx/cbits/psx/License
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only */
+
 Unless otherwise *explicitly* stated, the following text describes the
 licensed conditions under which the contents of this libcap/psx release
 may be used and distributed.

--- a/psx/cbits/psx/psx.c
+++ b/psx/cbits/psx/psx.c
@@ -516,7 +516,7 @@ int __wrap_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     pthread_sigmask(SIG_BLOCK, &sigbit, NULL);
 
     int ret = __real_pthread_create(thread, attr, _psx_start_fn, starter);
-    if (ret == -1) {
+    if (ret > 0) {
 	psx_new_state(_PSX_CREATE, _PSX_IDLE);
 	memset(starter, 0, sizeof(*starter));
 	free(starter);


### PR DESCRIPTION
Retrieved from upstream at
https://git.kernel.org/pub/scm/libs/libcap/libcap.git ref e79c7f06e1713eaae11119de4d8abfb4c77c6428.

`libpsx` is written by Andrew G. Morgan <morgan@kernel.org>. See `cbits/psx/License`.

See: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/tree/psx?id=e79c7f06e1713eaae11119de4d8abfb4c77c6428