### PR TITLE
landlock, psx: update dependency version bounds

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -251,6 +251,36 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set filepath-1.5
+        run: |
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.5' all --dry-run ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.5' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.5' all ; fi
+      - name: constraint set filepath-1.4
+        run: |
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.4' all --dry-run ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.4' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='filepath ^>=1.4' all ; fi
+      - name: constraint set tasty-1.5
+        run: |
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.5' all --dry-run ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.5' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.5' all ; fi
+      - name: constraint set tasty-1.4
+        run: |
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.4' all --dry-run ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.4' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='tasty ^>=1.4' all ; fi
+      - name: constraint set optparse-applicative-0.18
+        run: |
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='optparse-applicative ^>=0.18' all --dry-run ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='optparse-applicative ^>=0.18' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='optparse-applicative ^>=0.18' all ; fi
       - name: constraint set optparse-applicative-0.17
         run: |
           if [ $((HCNUMVER >= 90400 && HCNUMVER < 90600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='optparse-applicative ^>=0.17' all --dry-run ; fi

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -22,3 +22,23 @@ Constraint-Set optparse-applicative-0.16
 Constraint-Set optparse-applicative-0.17
   Constraints: optparse-applicative ^>=0.17
   Ghc: ^>=9.4
+
+Constraint-Set optparse-applicative-0.18
+  Constraints: optparse-applicative ^>=0.18
+  Ghc: ^>=9.8
+
+Constraint-Set tasty-1.4
+  Constraints: tasty ^>=1.4
+  Ghc: ^>=9.8
+
+Constraint-Set tasty-1.5
+  Constraints: tasty ^>=1.5
+  Ghc: ^>=9.8
+
+Constraint-Set filepath-1.4
+  Constraints: filepath ^>=1.4
+  Ghc: ^>=9.8
+
+Constraint-Set filepath-1.5
+  Constraints: filepath ^>=1.5
+  Ghc: ^>=9.8

--- a/landlock/CHANGELOG.md
+++ b/landlock/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## 0.2.2.0 -- YYYY-MM-DD
 
-* Update Cabal file formatting
-* Support GHC 9.6.4 / `base ^>=4.18`
-* Support GHC 9.8.2 / `base ^>=4.19`
+* Update Cabal file formatting.
+
+* Support GHC 9.6.4 / `base ^>=4.18`.
+
+* Support GHC 9.8.2 / `base ^>=4.19`.
+
+* Support `optparse-applicative ^>=0.18`.
+
+* Support `tasty ^>=1.5`.
+
+* Support `filepath ^>=1.5`.
 
 ## 0.2.1.1 -- 2023-02-28
 

--- a/landlock/landlock.cabal
+++ b/landlock/landlock.cabal
@@ -138,7 +138,7 @@ executable landlocked
     , base                  >=4.14.2.0  && <4.20
     , exceptions            ^>=0.10.4
     , landlock
-    , optparse-applicative  ^>=0.16.1.0 || ^>=0.17
+    , optparse-applicative  ^>=0.16.1.0 || ^>=0.17 || ^>=0.18
     , unix                  ^>=2.7.2.2  || ^>=2.8
 
 test-suite landlock-test
@@ -150,13 +150,13 @@ test-suite landlock-test
   build-depends:
     , async                    ^>=2.2.3
     , base                     >=4.14.2.0  && <4.20
-    , filepath                 ^>=1.4.2.1
+    , filepath                 ^>=1.4.2.1  || ^>=1.5
     , landlock
     , landlock-internal
     , process                  ^>=1.6.9.0
     , QuickCheck               ^>=2.14.2
     , quickcheck-classes-base  ^>=0.6.2.0
-    , tasty                    ^>=1.4.1
+    , tasty                    ^>=1.4.1    || ^>=1.5
     , tasty-hunit              ^>=0.10.0.3
     , tasty-quickcheck         ^>=0.10.1.2
 
@@ -177,7 +177,7 @@ test-suite landlock-test-threaded
     , async        ^>=2.2.3
     , base         >=4.14.2.0  && <4.20
     , landlock
-    , tasty        ^>=1.4.1
+    , tasty        ^>=1.4.1    || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
 
   ghc-options:      -threaded -with-rtsopts -N2
@@ -192,7 +192,7 @@ test-suite landlock-readme
   build-depends:
     , base       >=4.14.2.0 && <4.20
     , directory  ^>=1.3.6.0
-    , filepath   ^>=1.4.2.1
+    , filepath   ^>=1.4.2.1 || ^>=1.5
     , landlock
     , process    ^>=1.6.9.0
     , temporary  ^>=1.3
@@ -211,9 +211,9 @@ test-suite landlocked-test
   main-is:            landlocked-test.hs
   build-depends:
     , base         >=4.14.2.0  && <4.20
-    , filepath     ^>=1.4.2.1
+    , filepath     ^>=1.4.2.1  || ^>=1.5
     , process      ^>=1.6.9.0
-    , tasty        ^>=1.4.1
+    , tasty        ^>=1.4.1    || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
     , temporary    ^>=1.3
 

--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Update vendored sources.
 
+* Support `tasty ^>=1.5`
+
 ## 0.1.1.1 -- 2023-02-28
 
 * Remove `-Wl,-undefined,__wrap_sigfillset` from link options.

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -118,7 +118,7 @@ test-suite psx-test-threaded
     , async        ^>=2.2.3
     , base         >=4.14.2.0  && <4.20
     , psx
-    , tasty        ^>=1.4.1
+    , tasty        ^>=1.4.1    || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
 
   ghc-options:      -threaded -with-rtsopts -N2
@@ -136,7 +136,7 @@ test-suite psx-test
     , async        ^>=2.2.3
     , base         >=4.14.2.0  && <4.20
     , psx
-    , tasty        ^>=1.4.1
+    , tasty        ^>=1.4.1    || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
 
   other-extensions: CApiFFI
@@ -150,7 +150,7 @@ test-suite psx-test-no-psx
   include-dirs:     test cbits
   build-depends:
     , base         >=4.14.2.0  && <4.20
-    , tasty        ^>=1.4.1
+    , tasty        ^>=1.4.1    || ^>=1.5
     , tasty-hunit  ^>=0.10.0.3
 
   other-extensions: CApiFFI


### PR DESCRIPTION
- `optparse-applicative ^>=0.18`
- `tasty ^>=1.5`
- `filepath ^>=1.5`