### PR TITLE
psx: work-around `hsc2hs` linking issue

### DIFF
--- a/psx/CHANGELOG.md
+++ b/psx/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 * Update vendored sources.
 
-* Support `tasty ^>=1.5`
+* Support `tasty ^>=1.5`.
+
+* Fix build on platforms where a `hsc2hs` build links in `libgcc` which relies on
+  `sigfillset`. This requires the Cabal format version to be bumped to 3.6.
 
 ## 0.1.1.1 -- 2023-02-28
 

--- a/psx/psx.cabal
+++ b/psx/psx.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.2
+cabal-version:      3.6
 build-type:         Simple
 name:               psx
 version:            0.1.1.1
@@ -35,6 +35,7 @@ extra-source-files:
   cbits/hs-psx.h
   cbits/psx/psx_syscall.h
   test/detect-psx.h
+  test/hsc2hs-stubs.c
 
 tested-with:
   GHC ==8.10.7
@@ -113,6 +114,7 @@ test-suite psx-test-threaded
   main-is:          psx-test-threaded.hs
   other-modules:    TestCases
   c-sources:        test/detect-psx.c
+  hsc2hs-options:   -i hsc2hs-stubs.c
   include-dirs:     test
   build-depends:
     , async        ^>=2.2.3
@@ -131,6 +133,7 @@ test-suite psx-test
   main-is:          psx-test.hs
   other-modules:    TestCases
   c-sources:        test/detect-psx.c
+  hsc2hs-options:   -i hsc2hs-stubs.c
   include-dirs:     test
   build-depends:
     , async        ^>=2.2.3

--- a/psx/test/hsc2hs-stubs.c
+++ b/psx/test/hsc2hs-stubs.c
@@ -1,0 +1,20 @@
+/* Stubs for linking `hsc2hs` programs to succeed.
+ *
+ * For some reason, `cabal` passes a library's `ld-options` to the C compiler
+ * when building `hsc2hs` C files. However, in our case, these flags request
+ * wrapping of (e.g.) `sigfillset`. On some platforms, `libgcc` gets linked in
+ * as well, and on some platforms this `libgcc` relies on `sigfillset`, hence
+ * linking fails unless `__wrap_sigfillset` is declared.
+ *
+ * This module relays calls to the underlying `__real_*` implementation.
+ *
+ * See https://github.com/haskell/cabal/issues/8824
+ */
+
+#include <signal.h>
+
+extern int __real_sigfillset(sigset_t *set);
+
+int __wrap_sigfillset(sigset_t *set) {
+        return __real_sigfillset(set);
+}


### PR DESCRIPTION
On some platforms, building a `hsc2hs` program requires `libgcc`, and on some platforms, `libgcc` uses `sigfillset`. For some reason (a bug, I'd say), `cabal` passes `ld-options` to the compiler when building the generated C file. In our case, this causes `sigfillset` to be wrapped (which is desired for the actual `psx` library), but since `__wrap_sigfillset` is never defined, the build fails.

This work-around tells `hsc2hs` to include a small C file in its generated sources which defines `__wrap_sigfillset` as a proxy for `__real_sigfillset`.

See: https://github.com/haskell/cabal/issues/8824