### PR TITLE
landlock: improve `README.lhs` test

### DIFF
--- a/landlock/README.md
+++ b/landlock/README.md
@@ -105,9 +105,7 @@ main = withFakeRoot $ \root -> do
         readFile ("/etc" </> "hosts")
 
   where
-    lookupAccessFsFlags version = case lookup version accessFsFlags of
-        -- In a production implementation, we'd lookup the "best matching" flag
-        -- set, not require an exact match.
+    lookupAccessFsFlags version = case lookupMax version accessFsFlags of
         Nothing -> fail "Unsupported ABI version"
         Just flags -> return flags
 
@@ -115,4 +113,10 @@ main = withFakeRoot $ \root -> do
         _ <- act
         fail "Expected permission error"
     permissionDenied e = if isPermissionError e then Just () else Nothing
+
+    lookupMax key = fmap snd
+                  . listToMaybe
+                  . reverse
+                  . sort
+                  . filter (\(k, _) -> key >= k)
 ```

--- a/landlock/test/ReadmeUtils.hs
+++ b/landlock/test/ReadmeUtils.hs
@@ -4,6 +4,10 @@ module ReadmeUtils
     handleJust,
     -- Control.Monad
     unless,
+    -- Data.List
+    sort,
+    -- Data.Maybe
+    listToMaybe,
     -- System.Directory
     removeFile,
     -- System.FilePath
@@ -22,6 +26,8 @@ where
 
 import Control.Exception.Base (handleJust)
 import Control.Monad (unless)
+import Data.List (sort)
+import Data.Maybe (listToMaybe)
 import System.Directory (createDirectory, removeFile)
 import System.FilePath ((</>))
 import System.IO (IOMode (..), hPutStrLn, withFile)


### PR DESCRIPTION
The test used to have a comment explaining what the code *should* do, and failed on systems where the Landlock ABI supported by the kernel is higher than the ABI supported by this library.

Hence, updating the test to do what production code could/should do.